### PR TITLE
feat: mod:credential-proxy — scoped token auth loopback proxy

### DIFF
--- a/src/breadforge/agents/runner.py
+++ b/src/breadforge/agents/runner.py
@@ -36,11 +36,23 @@ class RunResult:
         return None
 
 
-def _build_env(model: str) -> dict[str, str]:
-    """Build subprocess environment — explicit allowlist, no credential leakage."""
+def _build_env(
+    model: str,
+    *,
+    proxy_url: str | None = None,
+    proxy_token: str | None = None,
+) -> dict[str, str]:
+    """Build subprocess environment — explicit allowlist, no credential leakage.
+
+    When *proxy_url* and *proxy_token* are supplied the agent subprocess routes
+    its Anthropic API calls through the loopback credential proxy instead of
+    receiving the real API key directly.  Raw API keys for other services are
+    withheld when the proxy is active so that the scoped token is the only
+    credential available to the agent.
+    """
     env: dict[str, str] = {}
 
-    for key in (
+    always_pass = (
         "HOME",
         "PATH",
         "SHELL",
@@ -51,15 +63,25 @@ def _build_env(model: str) -> dict[str, str]:
         "TERM",
         "GH_TOKEN",
         "GITHUB_TOKEN",
-        "ANTHROPIC_API_KEY",
-        "OPENAI_API_KEY",
-        "GOOGLE_API_KEY",
         "BREADMIN_DB_PATH",
         "BREADFORGE_MODEL",
-    ):
+    )
+    for key in always_pass:
         val = os.environ.get(key)
         if val is not None:
             env[key] = val
+
+    if proxy_url and proxy_token:
+        # Route the agent's Anthropic calls through the credential proxy.
+        # Do NOT forward real API keys — the scoped token is the only credential.
+        env["ANTHROPIC_BASE_URL"] = proxy_url
+        env["ANTHROPIC_API_KEY"] = proxy_token
+    else:
+        # No proxy: forward real API keys from the orchestrator environment.
+        for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
+            val = os.environ.get(key)
+            if val is not None:
+                env[key] = val
 
     env["BREADFORGE_MODEL"] = model
     env["BREADFORGE_AGENT"] = "1"
@@ -79,18 +101,34 @@ async def run_agent(
     timeout_minutes: int = 60,
     cwd: Path | None = None,
     allowed_tools: list[str] | None = None,
+    proxy_url: str | None = None,
+    proxy_token: str | None = None,
 ) -> RunResult:
-    """Spawn a headless Claude Code agent and wait for completion."""
+    """Spawn a headless Claude Code agent and wait for completion.
+
+    When *proxy_url* and *proxy_token* are provided the subprocess routes its
+    Anthropic API requests through the loopback credential proxy rather than
+    using a raw API key.
+    """
     start = datetime.now(UTC)
 
     # Prompt must come before --allowedTools; otherwise the claude CLI
     # misparses the positional argument and raises "Input must be provided".
-    cmd = ["claude", "--output-format", "stream-json", "--verbose", "--model", model, "--print", prompt]
+    cmd = [
+        "claude",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        model,
+        "--print",
+        prompt,
+    ]
 
     if allowed_tools:
         cmd += ["--allowedTools", ",".join(allowed_tools)]
 
-    env = _build_env(model)
+    env = _build_env(model, proxy_url=proxy_url, proxy_token=proxy_token)
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,

--- a/src/breadforge/health.py
+++ b/src/breadforge/health.py
@@ -112,7 +112,21 @@ def run_health_checks(repo: str) -> HealthReport:
             )
         )
 
-    # 6. Not running inside Claude Code (nesting guard)
+    # 6. Credential proxy secret
+    if os.environ.get("BREADFORGE_PROXY_SECRET"):
+        checks.append(
+            CheckResult("proxy-secret", CheckStatus.PASS, "BREADFORGE_PROXY_SECRET is set")
+        )
+    else:
+        checks.append(
+            CheckResult(
+                "proxy-secret",
+                CheckStatus.WARN,
+                "BREADFORGE_PROXY_SECRET not set — proxy will use an ephemeral per-session key",
+            )
+        )
+
+    # 7. Not running inside Claude Code (nesting guard)
     if os.environ.get("BREADFORGE_AGENT") == "1":
         checks.append(
             CheckResult(

--- a/src/breadforge/proxy/__init__.py
+++ b/src/breadforge/proxy/__init__.py
@@ -1,0 +1,28 @@
+"""Loopback credential proxy — scoped token issuance and HTTP proxy server.
+
+The proxy replaces raw API key injection in agent subprocesses.  Each agent
+subprocess receives a short-lived scoped token instead of a real API key.
+The loopback server validates the token and injects the real credential before
+forwarding to the upstream API.
+
+Quick usage::
+
+    from breadforge.proxy import CredentialProxy
+
+    with CredentialProxy() as proxy:
+        token = proxy.issue_token("anthropic", node_id="v1-build-core")
+        # Set in subprocess env:
+        #   ANTHROPIC_BASE_URL = proxy.base_url
+        #   ANTHROPIC_API_KEY  = token
+"""
+
+from breadforge.proxy.server import CredentialProxy
+from breadforge.proxy.token import ScopedToken, TokenError, issue_token, validate_token
+
+__all__ = [
+    "CredentialProxy",
+    "ScopedToken",
+    "TokenError",
+    "issue_token",
+    "validate_token",
+]

--- a/src/breadforge/proxy/server.py
+++ b/src/breadforge/proxy/server.py
@@ -1,0 +1,231 @@
+"""Loopback credential proxy server.
+
+Listens on 127.0.0.1 (random port) and forwards requests to upstream AI APIs.
+Each request must carry a scoped proxy token in the Authorization or x-api-key
+header; the proxy validates the token, replaces it with the real API key, and
+streams the response back to the caller.
+
+Upstream routing by scope:
+  anthropic → https://api.anthropic.com
+  openai    → https://api.openai.com
+  google    → https://generativelanguage.googleapis.com
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import httpx
+
+from breadforge.proxy.token import ScopedToken, TokenError, issue_token, validate_token
+
+# Real API key env-var names per scope
+_KEY_ENVVAR: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+}
+
+_UPSTREAM_BASE: dict[str, str] = {
+    "anthropic": "https://api.anthropic.com",
+    "openai": "https://api.openai.com",
+    "google": "https://generativelanguage.googleapis.com",
+}
+
+# Headers that must not be forwarded verbatim
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+        "content-length",
+    }
+)
+
+
+def _extract_token(headers: Any) -> str | None:
+    """Pull token string from Authorization: Bearer/x-api-key, or x-api-key header."""
+    auth = headers.get("Authorization") or headers.get("authorization") or ""
+    if auth.lower().startswith("bearer "):
+        return auth[7:]
+    if auth.lower().startswith("x-api-key "):
+        return auth[10:]
+    return headers.get("x-api-key") or headers.get("X-Api-Key") or None
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    """Request handler that validates a scoped token and proxies the request."""
+
+    # Injected by CredentialProxy when the handler class is created
+    proxy: CredentialProxy
+
+    def _reject(self, code: int, message: str) -> None:
+        body = message.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _handle(self) -> None:
+        token_str = _extract_token(self.headers)
+        if not token_str:
+            self._reject(401, "missing credential token")
+            return
+
+        try:
+            scoped: ScopedToken = validate_token(token_str, secret=self.proxy._secret)
+        except TokenError as exc:
+            self._reject(401, str(exc))
+            return
+
+        upstream_base = _UPSTREAM_BASE.get(scoped.scope)
+        if not upstream_base:
+            self._reject(400, f"unknown scope: {scoped.scope!r}")
+            return
+
+        real_key = os.environ.get(_KEY_ENVVAR.get(scoped.scope, ""), "")
+
+        # Read request body
+        content_length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(content_length) if content_length else b""
+
+        # Build forwarded headers (strip hop-by-hop and auth)
+        fwd: dict[str, str] = {}
+        for k, v in self.headers.items():
+            if k.lower() in _HOP_BY_HOP:
+                continue
+            if k.lower() in ("authorization", "x-api-key"):
+                continue
+            fwd[k] = v
+
+        # Inject real credentials
+        if scoped.scope == "anthropic":
+            fwd["x-api-key"] = real_key
+        else:
+            fwd["Authorization"] = f"Bearer {real_key}"
+
+        url = upstream_base + self.path
+
+        try:
+            with httpx.stream(
+                self.command,
+                url,
+                headers=fwd,
+                content=body,
+                timeout=300.0,
+            ) as resp:
+                self.send_response(resp.status_code)
+                for k, v in resp.headers.items():
+                    if k.lower() in _HOP_BY_HOP:
+                        continue
+                    self.send_header(k, v)
+                self.end_headers()
+                for chunk in resp.iter_bytes():
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+        except httpx.RequestError as exc:
+            self._reject(502, f"upstream request failed: {exc}")
+
+    do_GET = _handle
+    do_POST = _handle
+    do_PUT = _handle
+    do_DELETE = _handle
+    do_PATCH = _handle
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: D102
+        pass  # suppress default stderr output
+
+
+class CredentialProxy:
+    """Loopback HTTP proxy that validates scoped tokens and injects real credentials.
+
+    Usage::
+
+        proxy = CredentialProxy()
+        proxy.start()
+        token = proxy.issue_token("anthropic", node_id="v1-build-core")
+        # pass token + proxy.base_url to agent subprocess
+        proxy.stop()
+
+    Or as a context manager::
+
+        with CredentialProxy() as proxy:
+            token = proxy.issue_token("anthropic", node_id="v1-build-core")
+            ...
+    """
+
+    def __init__(self, secret: bytes | None = None) -> None:
+        if secret is None:
+            key = os.environ.get("BREADFORGE_PROXY_SECRET", "")
+            # Use env secret if available; otherwise generate an ephemeral key.
+            secret = key.encode() if key else os.urandom(32)
+        self._secret: bytes = secret
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Bind to a random loopback port and start serving in a daemon thread."""
+        handler_cls = type("_Handler", (_ProxyHandler,), {"proxy": self})
+        self._server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True, name="breadforge-proxy"
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Shutdown the server and join the daemon thread."""
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+        if self._thread:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> CredentialProxy:
+        self.start()
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def port(self) -> int:
+        """Bound port number. Only valid after start()."""
+        if not self._server:
+            raise RuntimeError("proxy has not been started")
+        return self._server.server_address[1]  # type: ignore[return-value]
+
+    @property
+    def base_url(self) -> str:
+        """Base URL to pass as ANTHROPIC_BASE_URL / OPENAI_BASE_URL."""
+        return f"http://127.0.0.1:{self.port}"
+
+    @property
+    def running(self) -> bool:
+        return self._server is not None
+
+    # ------------------------------------------------------------------
+    # Token issuance
+    # ------------------------------------------------------------------
+
+    def issue_token(self, scope: str, node_id: str, *, expires_seconds: int = 3600) -> str:
+        """Issue a scoped token for *node_id* using this proxy's secret."""
+        return issue_token(scope, node_id, secret=self._secret, expires_seconds=expires_seconds)

--- a/src/breadforge/proxy/token.py
+++ b/src/breadforge/proxy/token.py
@@ -1,0 +1,113 @@
+"""HMAC-signed scoped credential tokens for the loopback proxy.
+
+Token format: base64url(json_payload).<hmac_sha256_hex>
+
+The payload carries:
+  scope   — which upstream API this token may access ("anthropic"|"openai"|"google")
+  node_id — graph node that was issued this token (for audit)
+  exp     — unix timestamp after which the token is rejected
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass
+
+VALID_SCOPES = frozenset({"anthropic", "openai", "google"})
+
+
+class TokenError(Exception):
+    """Raised when a token cannot be issued or validated."""
+
+
+@dataclass
+class ScopedToken:
+    scope: str
+    node_id: str
+    expires_at: float
+
+    @property
+    def expired(self) -> bool:
+        return time.time() > self.expires_at
+
+
+def _require_secret() -> bytes:
+    key = os.environ.get("BREADFORGE_PROXY_SECRET", "")
+    if not key:
+        raise TokenError("BREADFORGE_PROXY_SECRET not set")
+    return key.encode()
+
+
+def issue_token(
+    scope: str,
+    node_id: str,
+    *,
+    secret: bytes | None = None,
+    expires_seconds: int = 3600,
+) -> str:
+    """Return a signed scoped token string.
+
+    Args:
+        scope: One of "anthropic", "openai", "google".
+        node_id: Graph node that is being issued this token.
+        secret: HMAC key bytes. Falls back to BREADFORGE_PROXY_SECRET env var.
+        expires_seconds: Lifetime in seconds (default 1 hour).
+    """
+    if scope not in VALID_SCOPES:
+        raise TokenError(f"unknown scope {scope!r}; must be one of {sorted(VALID_SCOPES)}")
+    if secret is None:
+        secret = _require_secret()
+
+    payload = {"scope": scope, "node_id": node_id, "exp": time.time() + expires_seconds}
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    sig = hmac.new(secret, payload_b64.encode(), hashlib.sha256).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def validate_token(token: str, *, secret: bytes | None = None) -> ScopedToken:
+    """Validate *token* and return a ScopedToken.
+
+    Raises TokenError on any validation failure (malformed, bad signature, expired).
+    """
+    if secret is None:
+        secret = _require_secret()
+
+    try:
+        payload_b64, sig = token.rsplit(".", 1)
+    except ValueError:
+        raise TokenError("malformed token: missing signature separator") from None
+
+    expected = hmac.new(secret, payload_b64.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        raise TokenError("invalid token signature")
+
+    # Restore padding stripped by issue_token
+    padding = 4 - len(payload_b64) % 4
+    if padding != 4:
+        payload_b64 += "=" * padding
+
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+    except Exception as exc:
+        raise TokenError(f"malformed token payload: {exc}") from exc
+
+    try:
+        tok = ScopedToken(
+            scope=payload["scope"],
+            node_id=payload["node_id"],
+            expires_at=float(payload["exp"]),
+        )
+    except KeyError as exc:
+        raise TokenError(f"missing field in token payload: {exc}") from exc
+
+    if tok.scope not in VALID_SCOPES:
+        raise TokenError(f"unknown scope in token: {tok.scope!r}")
+    if tok.expired:
+        raise TokenError("token has expired")
+
+    return tok


### PR DESCRIPTION
## Summary

- **`proxy/token.py`**: HMAC-SHA256 signed scoped tokens (scopes: `anthropic`, `openai`, `google`) with configurable expiry. `issue_token()` and `validate_token()` validate scope, signature, and expiry. Falls back to `BREADFORGE_PROXY_SECRET` env var for the signing key.
- **`proxy/server.py`**: `CredentialProxy` — a loopback HTTP server (`127.0.0.1`, random port) that validates scoped tokens, strips them, injects the real API key, and streams responses (including SSE) back to the caller. Runs in a daemon thread; usable as a context manager.
- **`proxy/__init__.py`**: Package exports (`CredentialProxy`, `issue_token`, `validate_token`, `ScopedToken`, `TokenError`).
- **`agents/runner.py`**: `_build_env` and `run_agent` accept `proxy_url`/`proxy_token` kwargs. When the proxy is active, real API keys are withheld from agent subprocesses; `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` are set to proxy endpoint + scoped token instead.
- **`health.py`**: Added `proxy-secret` preflight check — warns (`WARN`) when `BREADFORGE_PROXY_SECRET` is not set (proxy falls back to ephemeral per-session key).

## Test plan

- [x] All 76 existing unit tests pass (`uv run pytest tests/unit/ --ignore=tests/unit/test_assessor.py`)
- [x] `ruff check` clean on all modified/created files
- [x] `ruff format --check` clean on all modified/created files
- [ ] Pre-existing failure in `test_assessor.py::TestAllocator::test_allocate_low_confidence_upgrades` is out of scope (in `mod:assessor`, not `mod:credential-proxy`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)