### PR TITLE
feat: mod:consensus — wait/consensus/design_doc handlers, BackendRouter, CredentialProxy

### DIFF
--- a/src/breadforge/graph/builder.py
+++ b/src/breadforge/graph/builder.py
@@ -1,17 +1,30 @@
 """Graph builder — creates initial ExecutionGraph from a spec + milestone.
 
-Three entry points:
-  build_greenfield_graph  — new project, starts with a plan node
-  build_feature_graph     — feature on existing codebase, starts with a plan node
-  build_bug_graph         — bug fix, starts with a research node then plan
+Core entry points:
+  build_greenfield_graph       — new project, starts with a plan node
+  build_feature_graph          — feature on existing codebase, starts with a plan node
+  build_bug_graph              — bug fix, starts with a research node then plan
+
+Cross-repo blocking:
+  apply_cross_repo_blocking    — inject wait nodes for milestones that depend on
+                                 other repos/milestones via CampaignBead.blocked_by.
+
+Consensus/design-doc helpers:
+  emit_consensus_node          — emit a consensus node that votes over proposals
+  emit_design_doc_node         — emit a design_doc node for a given task
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from breadforge.beads.types import GraphNode
 from breadforge.graph.executor import ExecutionGraph
+from breadforge.graph.node import make_node
+
+if TYPE_CHECKING:
+    from breadforge.beads.store import BeadStore
 
 
 def build_greenfield_graph(
@@ -91,3 +104,152 @@ def build_bug_graph(
         },
     )
     return ExecutionGraph([research_node, plan_node])
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo blocking via CampaignBead
+# ---------------------------------------------------------------------------
+
+
+def apply_cross_repo_blocking(
+    graph: ExecutionGraph,
+    milestone: str,
+    repo: str,
+    store: BeadStore,
+) -> ExecutionGraph:
+    """Inject wait nodes for any cross-repo blockers declared in CampaignBead.
+
+    Reads ``CampaignBead.milestones[milestone].blocked_by`` for *repo*.  Each
+    ``"owner/repo:milestone"`` string becomes a ``wait`` node that is prepended
+    as a dependency to every current pending node in the graph.
+
+    Returns the same graph (mutated in-place) for chaining.
+
+    Example
+    -------
+    If the campaign declares that ``owner/myrepo:v2`` is blocked by
+    ``owner/otherrepo:v1``, this function adds::
+
+        wait-v2-otherrepo-v1  (type="wait", max_retries=60)
+
+    and rewires every existing pending node to depend on it.
+    """
+    campaign = store.read_campaign_bead()
+    if not campaign:
+        return graph
+
+    plan = campaign.get_milestone(milestone, repo=repo)
+    if not plan or not plan.blocked_by:
+        return graph
+
+    wait_nodes: list[GraphNode] = []
+    for blocker_ref in plan.blocked_by:
+        # Derive a stable node ID from the ref
+        safe_ref = blocker_ref.replace("/", "-").replace(":", "-")
+        node_id = f"wait-{milestone}-{safe_ref}"
+        wait_node = make_node(
+            id=node_id,
+            type="wait",
+            context={
+                "blocking_milestones": [blocker_ref],
+                "milestone": milestone,
+                "repo": repo,
+            },
+            max_retries=60,  # ~1 hour at 60 s per retry
+        )
+        wait_nodes.append(wait_node)
+
+    if not wait_nodes:
+        return graph
+
+    # Add wait nodes to the graph first
+    graph.add_nodes(wait_nodes)
+    wait_ids = [n.id for n in wait_nodes]
+
+    # Prepend wait_ids as dependencies on all currently pending non-wait nodes
+    for node in graph.all_nodes():
+        if node.state != "pending":
+            continue
+        if node.id in wait_ids:
+            continue  # don't create self-dependency
+        for wid in wait_ids:
+            if wid not in node.depends_on:
+                node.depends_on.append(wid)
+
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Consensus and design_doc node emitters
+# ---------------------------------------------------------------------------
+
+
+def emit_wait_node(
+    milestone: str,
+    blocking_milestones: list[str],
+    depends_on: list[str] | None = None,
+    max_retries: int = 60,
+) -> GraphNode:
+    """Create a single wait node that blocks on *blocking_milestones*."""
+    safe = "-".join(r.replace("/", "-").replace(":", "-") for r in blocking_milestones[:2])
+    return make_node(
+        id=f"{milestone}-wait-{safe}",
+        type="wait",
+        depends_on=depends_on or [],
+        context={
+            "blocking_milestones": blocking_milestones,
+            "milestone": milestone,
+        },
+        max_retries=max_retries,
+    )
+
+
+def emit_consensus_node(
+    milestone: str,
+    proposal_node_ids: list[str],
+    selection_model: str | None = None,
+) -> GraphNode:
+    """Create a consensus node that selects among completed proposal nodes."""
+    slug = "-".join(nid.split("-")[-1] for nid in proposal_node_ids[:3])
+    context: dict = {
+        "proposal_node_ids": proposal_node_ids,
+        "milestone": milestone,
+    }
+    if selection_model:
+        context["selection_model"] = selection_model
+    return make_node(
+        id=f"{milestone}-consensus-{slug}",
+        type="consensus",
+        depends_on=list(proposal_node_ids),
+        context=context,
+        max_retries=2,
+    )
+
+
+def emit_design_doc_node(
+    milestone: str,
+    title: str,
+    requirements: str,
+    constraints: str = "",
+    depends_on: list[str] | None = None,
+    design_model: str | None = None,
+) -> GraphNode:
+    """Create a design_doc node that generates a design document via LLM."""
+    import re
+
+    slug = re.sub(r"[^a-zA-Z0-9]", "-", title)[:30].strip("-").lower()
+    context: dict = {
+        "title": title,
+        "requirements": requirements,
+        "constraints": constraints,
+        "milestone": milestone,
+    }
+    if design_model:
+        context["design_model"] = design_model
+    return make_node(
+        id=f"{milestone}-design-doc-{slug}",
+        type="design_doc",
+        depends_on=depends_on or [],
+        context=context,
+        max_retries=2,
+    )

--- a/src/breadforge/graph/executor.py
+++ b/src/breadforge/graph/executor.py
@@ -5,6 +5,7 @@ Key design:
 - _add_overlap_edges adds sequential deps between build nodes that touch the same files
 - GraphExecutor drives the async event loop: dispatch ready nodes, handle completions,
   expand graph when plan nodes emit new_nodes
+- BackendRouter (optional) overrides per-node model selection based on node type
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from breadforge.beads.types import GraphNode, NodeType
-from breadforge.graph.node import NodeHandler, NodeResult
+from breadforge.graph.node import BackendRouter, NodeHandler, NodeResult
 
 if TYPE_CHECKING:
     from breadforge.beads.store import BeadStore
@@ -139,6 +140,7 @@ class GraphExecutor:
         concurrency: int = 3,
         watchdog_interval: float = 60.0,
         dry_run: bool = False,
+        backend_router: BackendRouter | None = None,
     ) -> None:
         self._config = config
         self._handlers = handlers
@@ -147,6 +149,7 @@ class GraphExecutor:
         self._concurrency = concurrency
         self._watchdog_interval = watchdog_interval
         self._dry_run = dry_run
+        self._backend_router = backend_router
 
     def _restore_from_store(self, graph: ExecutionGraph, result: ExecutionResult) -> None:
         """Restore terminal node states and replay plan node expansions.
@@ -262,8 +265,16 @@ class GraphExecutor:
         handler = self._handlers.get(node.type)
         if handler is None:
             return NodeResult(success=False, error=f"no handler for type {node.type!r}")
+        # Apply BackendRouter model override when the node has no explicit model
+        effective_config = self._config
+        if self._backend_router and not node.assigned_model:
+            routed_model = self._backend_router.route(node.type)
+            if routed_model and routed_model != self._config.model:
+                from dataclasses import replace
+
+                effective_config = replace(self._config, model=routed_model)
         try:
-            return await handler.execute(node, self._config)
+            return await handler.execute(node, effective_config)
         except Exception as e:
             return NodeResult(success=False, error=str(e))
 
@@ -396,6 +407,7 @@ def make_handlers(
 ) -> dict[NodeType, NodeHandler]:
     """Instantiate all handlers. Import lazily to avoid circular deps."""
     from breadforge.graph.handlers.build import BuildHandler
+    from breadforge.graph.handlers.consensus import ConsensusHandler, DesignDocHandler, WaitHandler
     from breadforge.graph.handlers.merge import MergeHandler
     from breadforge.graph.handlers.plan import PlanHandler
     from breadforge.graph.handlers.readme import ReadmeHandler
@@ -407,4 +419,8 @@ def make_handlers(
         "build": BuildHandler(store=store, logger=logger),
         "merge": MergeHandler(store=store, logger=logger),
         "readme": ReadmeHandler(store=store, logger=logger),
+        # consensus module
+        "wait": WaitHandler(store=store, logger=logger),
+        "consensus": ConsensusHandler(store=store, logger=logger),
+        "design_doc": DesignDocHandler(store=store, logger=logger),
     }

--- a/src/breadforge/graph/handlers/consensus.py
+++ b/src/breadforge/graph/handlers/consensus.py
@@ -1,0 +1,401 @@
+"""Consensus module handlers: WaitHandler, ConsensusHandler, DesignDocHandler.
+
+WaitHandler
+    Polls cross-repo CampaignBead entries until all blocking milestones are
+    shipped.  Fails (triggering retry) while any upstream milestone is still
+    pending/implementing; succeeds once every blocker is ``shipped``.
+
+ConsensusHandler
+    Selects the best proposal from a set of candidates.  Candidates can be
+    passed directly in ``context["proposals"]`` or gathered from completed
+    dependent node outputs via ``context["proposal_node_ids"]``.  An LLM
+    call is used to pick the winner when more than one candidate exists.
+
+DesignDocHandler
+    Calls an LLM to produce a structured design document from a title,
+    requirements, and optional constraints stored in node context.  The
+    resulting doc is stored as a research finding and returned in output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+from breadforge.beads.types import GraphNode
+from breadforge.graph.node import NodeResult
+
+if TYPE_CHECKING:
+    from breadforge.beads.store import BeadStore
+    from breadforge.config import Config
+    from breadforge.logger import Logger
+
+# ---------------------------------------------------------------------------
+# WaitHandler
+# ---------------------------------------------------------------------------
+
+_WAIT_POLL_SECONDS = 60
+
+
+class WaitHandler:
+    """Waits for cross-repo milestone dependencies to be shipped.
+
+    Context keys
+    ------------
+    blocking_milestones : list[str]
+        ``"owner/repo:milestone"`` strings that must reach ``shipped`` status.
+
+    The handler returns failure while any blocker is unshipped (executor
+    will retry up to ``node.max_retries`` times).  Set ``max_retries``
+    proportionally to the expected wait time (e.g. 60 retries × 60 s =
+    1 hour).
+    """
+
+    def __init__(
+        self,
+        store: BeadStore | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        self._store = store
+        self._logger = logger
+
+    async def execute(self, node: GraphNode, config: Config) -> NodeResult:
+        blocking: list[str] = node.context.get("blocking_milestones", [])
+        if not blocking:
+            return NodeResult(success=True, output={"unblocked": True, "blocking": []})
+
+        unshipped = []
+        for ref in blocking:
+            if ":" not in ref:
+                if self._logger:
+                    self._logger.error(f"wait node {node.id}: invalid ref {ref!r}, skipping")
+                continue
+            repo, milestone = ref.split(":", 1)
+            if not self._is_shipped(repo.strip(), milestone.strip(), config):
+                unshipped.append(ref)
+
+        if unshipped:
+            if self._logger:
+                self._logger.info(
+                    f"wait node {node.id}: still blocked on {unshipped}",
+                    node_id=node.id,
+                )
+            # Brief sleep so retries do not hammer disk I/O in tight loops
+            await asyncio.sleep(_WAIT_POLL_SECONDS)
+            return NodeResult(
+                success=False,
+                error=f"blocked: waiting for {', '.join(unshipped)}",
+            )
+
+        if self._logger:
+            self._logger.info(f"wait node {node.id}: all blockers shipped", node_id=node.id)
+        return NodeResult(success=True, output={"unblocked": True, "blocking": blocking})
+
+    def recover(self, node: GraphNode, config: Config) -> NodeResult | None:
+        return None
+
+    def _is_shipped(self, repo: str, milestone: str, config: Config) -> bool:
+        if not self._store:
+            return False
+        from breadforge.beads.store import BeadStore
+
+        # Build a store scoped to the blocking repo
+        blocking_store = BeadStore(config.beads_dir, repo)
+        campaign = blocking_store.read_campaign_bead()
+        if not campaign:
+            return False
+        plan = campaign.get_milestone(milestone, repo=repo)
+        return plan is not None and plan.status == "shipped"
+
+
+# ---------------------------------------------------------------------------
+# ConsensusHandler
+# ---------------------------------------------------------------------------
+
+_CONSENSUS_PROMPT = """\
+You are selecting the best proposal from the following candidates.
+
+CANDIDATES:
+{candidates_text}
+
+Return a JSON object with exactly these keys:
+{{
+  "winner_index": <int, 0-based index of best proposal>,
+  "rationale": "<1-2 sentence explanation>"
+}}
+
+Prefer the proposal that is most concrete, feasible, and aligned with the
+system's existing architecture.  If all proposals are equivalent, pick the
+first.
+"""
+
+
+class ConsensusHandler:
+    """Selects the best proposal from multiple candidates.
+
+    Context keys
+    ------------
+    proposals : list[dict]
+        Each dict has ``"id"`` (str), ``"text"`` (str), and optionally
+        ``"source"`` (str).  Used directly when present.
+    proposal_node_ids : list[str]
+        IDs of completed dependent nodes whose ``output["proposal"]`` values
+        are collected as candidates.  Ignored when ``proposals`` is set.
+    selection_model : str
+        Optional model override for the selection LLM call.
+
+    Output keys
+    -----------
+    winner_id : str
+    winner_text : str
+    rationale : str
+    """
+
+    def __init__(
+        self,
+        store: BeadStore | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        self._store = store
+        self._logger = logger
+
+    async def execute(self, node: GraphNode, config: Config) -> NodeResult:
+        proposals: list[dict[str, Any]] = node.context.get("proposals", [])
+
+        if not proposals:
+            # Gather from completed dependent node outputs
+            node_ids: list[str] = node.context.get("proposal_node_ids", [])
+            proposals = self._gather_from_nodes(node_ids)
+
+        if not proposals:
+            return NodeResult(
+                success=False,
+                error="consensus node has no proposals (set context.proposals or proposal_node_ids)",
+            )
+
+        if len(proposals) == 1:
+            winner = proposals[0]
+            return NodeResult(
+                success=True,
+                output={
+                    "winner_id": winner.get("id", "0"),
+                    "winner_text": winner.get("text", ""),
+                    "rationale": "single candidate — no selection needed",
+                },
+            )
+
+        model = node.context.get("selection_model") or config.model
+        try:
+            winner_index, rationale = await self._call_selection_llm(proposals, model)
+        except Exception as e:
+            # Fallback: pick first candidate
+            if self._logger:
+                self._logger.error(
+                    f"consensus {node.id}: LLM selection failed ({e}), using first candidate",
+                    node_id=node.id,
+                )
+            winner_index, rationale = 0, f"LLM selection failed: {e}"
+
+        winner = proposals[winner_index] if winner_index < len(proposals) else proposals[0]
+        if self._logger:
+            self._logger.info(
+                f"consensus {node.id}: selected candidate {winner_index} — {rationale[:80]}",
+                node_id=node.id,
+            )
+        return NodeResult(
+            success=True,
+            output={
+                "winner_id": winner.get("id", str(winner_index)),
+                "winner_text": winner.get("text", ""),
+                "rationale": rationale,
+            },
+        )
+
+    def recover(self, node: GraphNode, config: Config) -> NodeResult | None:
+        return None
+
+    def _gather_from_nodes(self, node_ids: list[str]) -> list[dict[str, Any]]:
+        if not self._store or not node_ids:
+            return []
+        proposals = []
+        for nid in node_ids:
+            stored = self._store.read_node(nid)
+            if stored and stored.output:
+                text = stored.output.get("proposal") or stored.output.get("findings", "")
+                proposals.append({"id": nid, "text": str(text), "source": nid})
+        return proposals
+
+    async def _call_selection_llm(
+        self,
+        proposals: list[dict[str, Any]],
+        model: str,
+    ) -> tuple[int, str]:
+        candidates_text = "\n\n".join(
+            f"[{i}] (id={p.get('id', i)})\n{p.get('text', '')}" for i, p in enumerate(proposals)
+        )
+        prompt = _CONSENSUS_PROMPT.format(candidates_text=candidates_text)
+
+        try:
+            from breadmin_llm.registry import ProviderRegistry
+            from breadmin_llm.types import LLMCall, LLMMessage, MessageRole
+
+            registry = ProviderRegistry.default()
+            call = LLMCall(
+                model=model,
+                messages=[LLMMessage(role=MessageRole.USER, content=prompt)],
+                max_tokens=300,
+                caller="breadforge.consensus",
+            )
+            response = await registry.complete(call)
+            text = response.content
+        except ImportError:
+            import anthropic
+
+            client = anthropic.AsyncAnthropic()
+            response = await client.messages.create(
+                model=model,
+                max_tokens=300,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = response.content[0].text  # type: ignore[union-attr]
+
+        text = text.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            text = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+        data = json.loads(text)
+        return int(data["winner_index"]), str(data.get("rationale", ""))
+
+
+# ---------------------------------------------------------------------------
+# DesignDocHandler
+# ---------------------------------------------------------------------------
+
+_DESIGN_DOC_PROMPT = """\
+You are a software architect.  Generate a concise design document for the
+following task.
+
+TITLE: {title}
+
+REQUIREMENTS:
+{requirements}
+
+CONSTRAINTS:
+{constraints}
+
+Produce a well-structured markdown design document covering:
+1. Overview and goals
+2. Architecture / key components
+3. Data flow
+4. API / interface contracts (if applicable)
+5. Open questions and risks
+
+Be specific and practical.  Do not pad with boilerplate.
+"""
+
+
+class DesignDocHandler:
+    """Generates a design document via LLM and stores it as a research finding.
+
+    Context keys
+    ------------
+    title : str
+        Short title for the design doc.
+    requirements : str
+        What needs to be built.
+    constraints : str  (optional)
+        Technical constraints or non-goals.
+    design_model : str  (optional)
+        Model override for this call.
+
+    Output keys
+    -----------
+    doc : str          — raw markdown content
+    doc_path : str     — path where the doc was stored (if store is available)
+    """
+
+    def __init__(
+        self,
+        store: BeadStore | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        self._store = store
+        self._logger = logger
+
+    async def execute(self, node: GraphNode, config: Config) -> NodeResult:
+        title: str = node.context.get("title", node.id)
+        requirements: str = node.context.get("requirements", "")
+        constraints: str = node.context.get("constraints", "None specified.")
+        model: str = node.context.get("design_model") or config.model
+
+        if not requirements:
+            return NodeResult(
+                success=False,
+                error="design_doc node missing context.requirements",
+            )
+
+        prompt = _DESIGN_DOC_PROMPT.format(
+            title=title,
+            requirements=requirements[:4000],
+            constraints=constraints[:1000],
+        )
+
+        try:
+            doc = await self._call_design_llm(prompt, model)
+        except Exception as e:
+            return NodeResult(success=False, error=f"design_doc LLM call failed: {e}")
+
+        doc_path = ""
+        if self._store:
+            path = self._store.store_research_findings(node.id, doc)
+            doc_path = str(path)
+
+        if self._logger:
+            self._logger.info(
+                f"design_doc {node.id}: generated {len(doc)} chars",
+                node_id=node.id,
+            )
+
+        return NodeResult(
+            success=True,
+            output={"doc": doc, "doc_path": doc_path},
+        )
+
+    def recover(self, node: GraphNode, config: Config) -> NodeResult | None:
+        """Re-use a previously stored doc if the node crashed after storing."""
+        if not self._store:
+            return None
+        existing = self._store.read_research_findings(node.id)
+        if existing:
+            return NodeResult(
+                success=True,
+                output={"doc": existing, "doc_path": ""},
+            )
+        return None
+
+    async def _call_design_llm(self, prompt: str, model: str) -> str:
+        try:
+            from breadmin_llm.registry import ProviderRegistry
+            from breadmin_llm.types import LLMCall, LLMMessage, MessageRole
+
+            registry = ProviderRegistry.default()
+            call = LLMCall(
+                model=model,
+                messages=[LLMMessage(role=MessageRole.USER, content=prompt)],
+                max_tokens=2000,
+                caller="breadforge.design_doc",
+            )
+            response = await registry.complete(call)
+            return response.content
+        except ImportError:
+            import anthropic
+
+            client = anthropic.AsyncAnthropic()
+            response = await client.messages.create(
+                model=model,
+                max_tokens=2000,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.content[0].text  # type: ignore[union-attr]

--- a/src/breadforge/graph/node.py
+++ b/src/breadforge/graph/node.py
@@ -2,11 +2,18 @@
 
 Re-exports GraphNode/PlanArtifact/NodeType/NodeState from beads.types for
 convenience, and adds NodeResult + NodeHandler protocol used by handlers.
+
+Extended node types (wait/consensus/design_doc) are defined here as
+ExtendedNodeType.  Nodes with these types must be constructed via
+make_node() which uses model_construct() to bypass Pydantic's Literal
+validation on GraphNode.type.  Full persistence of extended types requires
+updating NodeType in beads/types.py.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from breadforge.beads.types import (
     GraphNode,
@@ -18,13 +25,29 @@ from breadforge.beads.types import (
 if TYPE_CHECKING:
     from breadforge.config import Config
 
+ExtendedNodeType = Literal[
+    "research",
+    "plan",
+    "build",
+    "merge",
+    "readme",
+    # consensus module additions
+    "wait",
+    "consensus",
+    "design_doc",
+]
+
 __all__ = [
     "GraphNode",
     "NodeState",
     "NodeType",
+    "ExtendedNodeType",
     "NodeResult",
     "NodeHandler",
     "PlanArtifact",
+    "BackendRouter",
+    "CredentialProxy",
+    "make_node",
 ]
 
 
@@ -55,7 +78,8 @@ class NodeResult:
 
 
 class NodeHandler(Protocol):
-    """Protocol that every handler (plan/research/build/merge) must implement."""
+    """Protocol that every handler (plan/research/build/merge/wait/consensus/design_doc)
+    must implement."""
 
     async def execute(self, node: GraphNode, config: Config) -> NodeResult:
         """Execute the node and return a result. Must not mutate graph state."""
@@ -69,3 +93,118 @@ class NodeHandler(Protocol):
         Default: return None (re-dispatch).
         """
         return None
+
+
+# ---------------------------------------------------------------------------
+# BackendRouter — pluggable LLM backend routing per node type
+# ---------------------------------------------------------------------------
+
+
+class BackendRouter:
+    """Routes node types to LLM backend model strings.
+
+    research/plan nodes default to ``research_model`` (may be Gemini or
+    GPT-4.1); build/merge/readme nodes default to ``build_model`` (Claude);
+    wait/consensus/design_doc nodes use ``design_model``.
+
+    Pass instances to GraphExecutor to override per-node model selection
+    without changing Config.model.
+    """
+
+    _RESEARCH_TYPES: frozenset[str] = frozenset({"research", "plan"})
+    _BUILD_TYPES: frozenset[str] = frozenset({"build", "merge", "readme"})
+
+    def __init__(
+        self,
+        build_model: str = "claude-sonnet-4-6",
+        research_model: str | None = None,
+        design_model: str | None = None,
+    ) -> None:
+        self.build_model = build_model
+        self.research_model = research_model or build_model
+        self.design_model = design_model or self.research_model
+
+    def route(self, node_type: str) -> str:
+        """Return the model string for the given node type."""
+        if node_type in self._RESEARCH_TYPES:
+            return self.research_model
+        if node_type in self._BUILD_TYPES:
+            return self.build_model
+        return self.design_model
+
+    @classmethod
+    def from_env(cls) -> BackendRouter:
+        """Construct from BREADFORGE_* environment variables."""
+        import os
+
+        return cls(
+            build_model=os.environ.get("BREADFORGE_BUILD_MODEL", "claude-sonnet-4-6"),
+            research_model=os.environ.get("BREADFORGE_RESEARCH_MODEL") or None,
+            design_model=os.environ.get("BREADFORGE_DESIGN_MODEL") or None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CredentialProxy — scoped token issuance (v0.2 passthrough)
+# ---------------------------------------------------------------------------
+
+
+class CredentialProxy:
+    """Issues scoped API tokens for agent sub-processes.
+
+    Prevents raw API key propagation by centralising credential access.
+    v0.2 is a passthrough wrapper; future versions may implement a loopback
+    HTTP proxy with per-scope rate limiting and audit logging.
+    """
+
+    _VALID_SCOPES = frozenset({"build", "research", "design", "merge"})
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key
+
+    def scoped_token(self, scope: str) -> str | None:
+        """Return a token valid for *scope*.  Returns the raw key in v0.2."""
+        if scope not in self._VALID_SCOPES:
+            raise ValueError(f"unknown scope {scope!r}; valid: {sorted(self._VALID_SCOPES)}")
+        return self._api_key
+
+    @classmethod
+    def from_env(cls) -> CredentialProxy:
+        import os
+
+        return cls(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+
+# ---------------------------------------------------------------------------
+# make_node — factory for extended node types
+# ---------------------------------------------------------------------------
+
+
+def make_node(
+    id: str,
+    type: str,
+    state: str = "pending",
+    depends_on: list[str] | None = None,
+    context: dict[str, Any] | None = None,
+    max_retries: int = 3,
+    assigned_model: str | None = None,
+) -> GraphNode:
+    """Construct a GraphNode, including extended types (wait/consensus/design_doc).
+
+    Uses model_construct() to bypass Pydantic's Literal validation so that
+    types outside of the core NodeType Literal are accepted at runtime.
+    """
+    return GraphNode.model_construct(
+        id=id,
+        type=type,
+        state=state,
+        depends_on=depends_on if depends_on is not None else [],
+        context=context if context is not None else {},
+        output=None,
+        assigned_model=assigned_model,
+        retry_count=0,
+        max_retries=max_retries,
+        created_at=datetime.now(UTC),
+        started_at=None,
+        completed_at=None,
+    )


### PR DESCRIPTION
## Summary

- **`graph/node.py`**: `ExtendedNodeType` adds `wait`/`consensus`/`design_doc` node types. `BackendRouter` routes research/plan nodes to a configurable model (e.g. Gemini/GPT-4.1) while build nodes stay on Claude. `CredentialProxy` centralises API key access with scope validation. `make_node()` factory creates nodes with extended types via `model_construct`.
- **`graph/handlers/consensus.py`** (new): `WaitHandler` polls cross-repo `CampaignBead` entries until blocking milestones reach `shipped`; `ConsensusHandler` selects the best proposal from candidates via LLM voting; `DesignDocHandler` generates design docs via LLM and stores them as research findings.
- **`graph/builder.py`**: `apply_cross_repo_blocking()` reads `CampaignBead.blocked_by` and injects wait nodes as dependencies on all pending graph nodes. `emit_wait_node`, `emit_consensus_node`, `emit_design_doc_node` helper functions for programmatic graph construction.
- **`graph/executor.py`**: `make_handlers()` registers the three new handlers; `GraphExecutor` accepts an optional `BackendRouter` and applies per-node model routing in `_dispatch()`.

## Notes

- **GitHub Actions workflow** (`.github/workflows/`) is not in the allowed file scope for this issue. Filed separately if needed.
- Extended node type persistence (`wait`/`consensus`/`design_doc` in `BeadStore.list_nodes`) requires adding these values to `NodeType` in `beads/types.py` (out of scope for `mod:consensus`). Nodes are fully functional in-memory via `make_node()`.

## Test plan

- [ ] Existing 93 passing tests continue to pass (6 pre-existing failures unrelated to this module)
- [ ] `WaitHandler.execute()` returns failure while blockers are unshipped, success once all are shipped
- [ ] `ConsensusHandler.execute()` short-circuits on single candidate; calls LLM for multi-candidate selection
- [ ] `DesignDocHandler.recover()` restores from stored research findings after crash
- [ ] `BackendRouter.route()` correctly maps research→research_model, build→build_model, design_doc→design_model
- [ ] `apply_cross_repo_blocking()` injects wait nodes and wires dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)