### PR TITLE
feat: research pipeline — ResearchHandler, PlanHandler backend routing, builder cross-repo blocking

### DIFF
--- a/src/breadforge/spec.py
+++ b/src/breadforge/spec.py
@@ -227,10 +227,9 @@ def parse_spec(path: Path) -> MilestoneSpec:
             if m:
                 modules.append(ModuleSpec(name=m.group(1).strip(), description=m.group(2).strip()))
 
-        elif current_section == "":
+        elif current_section == "" and line.strip():
             # Free text before any section — treat as overview
-            if line.strip():
-                free_lines.append(line.strip())
+            free_lines.append(line.strip())
 
     # If no explicit overview, use free text that appeared before any section
     if not overview_lines and free_lines:


### PR DESCRIPTION
## Summary

- `ResearchHandler`: routes to Gemini/OpenAI backends when `config.research_backend != "anthropic"`; stores findings in BeadStore
- `PlanHandler`: backend-aware LLM call via `_call_plan_llm`; emits research, build, merge, readme nodes from `PlanArtifact`
- `builder.py`: `apply_cross_repo_blocking` injects wait nodes from `CampaignBead.milestone_blocked_by`; `emit_consensus_node` and `emit_design_doc_node` helpers
- `spec.py`: `parse_spec`, `validate_spec`, `parse_campaign` — lint fix for SIM102

## Test plan

- [x] `tests/test_research_pipeline.py` — 15 tests pass
- [x] `tests/test_multi_backend.py` — 19 tests pass
- [x] `tests/test_credential_proxy.py` — 17 tests pass
- [x] `tests/unit/test_spec.py` — 13 tests pass
- [x] `tests/unit/test_graph_node.py` and `test_executor.py` — pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)