### PR TITLE
feat: add WaitHandler and extend NodeType (closes #2)

### DIFF
--- a/src/breadforge/beads/types.py
+++ b/src/breadforge/beads/types.py
@@ -141,7 +141,9 @@ class CampaignBead(BaseModel):
 # GraphNode + PlanArtifact (new DAG execution types)
 # ---------------------------------------------------------------------------
 
-NodeType = Literal["research", "plan", "build", "merge", "readme"]
+NodeType = Literal[
+    "research", "plan", "build", "merge", "readme", "wait", "consensus", "design_doc"
+]
 NodeState = Literal["pending", "running", "done", "failed", "abandoned"]
 
 

--- a/src/breadforge/graph/handlers/wait.py
+++ b/src/breadforge/graph/handlers/wait.py
@@ -1,0 +1,86 @@
+"""WaitHandler — condition-based DAG gate node.
+
+Polls a simple condition stored in node.context until it is satisfied or
+max_polls attempts are exhausted.  This is the general-purpose wait node used
+to implement synchronisation gates inside a single-repo DAG.  For cross-repo
+milestone blocking, see the CampaignBead-aware WaitHandler in consensus.py.
+
+Context keys
+------------
+condition : str
+    One of ``"always_true"``, ``"always_false"``, ``"file_exists"``.
+    Unknown values are treated as unsatisfied.
+path : str
+    File path tested by the ``"file_exists"`` condition.
+poll_interval : float
+    Seconds to sleep between poll attempts (default 0.05).
+max_polls : int
+    Maximum number of poll attempts before returning failure (default 3).
+
+Output keys (on success)
+------------------------
+polls : int   — number of attempts before the condition was met
+condition : str — the condition string that was evaluated
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from breadforge.beads.types import GraphNode
+from breadforge.graph.node import NodeResult
+
+if TYPE_CHECKING:
+    from breadforge.config import Config
+
+
+class WaitHandler:
+    """Polls a condition until satisfied or max_polls exhausted."""
+
+    def __init__(self, store=None, logger=None) -> None:
+        self._store = store
+        self._logger = logger
+
+    async def execute(self, node: GraphNode, config: Config) -> NodeResult:
+        condition: str = node.context.get("condition", "always_true")
+        poll_interval: float = float(node.context.get("poll_interval", 0.05))
+        max_polls: int = int(node.context.get("max_polls", 3))
+
+        for attempt in range(1, max_polls + 1):
+            if self._check(condition, node):
+                if self._logger:
+                    self._logger.info(
+                        f"wait node {node.id}: condition {condition!r} met after {attempt} poll(s)",
+                        node_id=node.id,
+                    )
+                return NodeResult(
+                    success=True,
+                    output={"polls": attempt, "condition": condition},
+                )
+            if attempt < max_polls:
+                await asyncio.sleep(poll_interval)
+
+        if self._logger:
+            self._logger.info(
+                f"wait node {node.id}: condition {condition!r} not met after {max_polls} polls",
+                node_id=node.id,
+            )
+        return NodeResult(
+            success=False,
+            error=f"wait condition {condition!r} not met after {max_polls} polls",
+        )
+
+    def _check(self, condition: str, node: GraphNode) -> bool:
+        if condition == "always_true":
+            return True
+        if condition == "always_false":
+            return False
+        if condition == "file_exists":
+            return Path(str(node.context.get("path", ""))).exists()
+        return False
+
+    def recover(self, node: GraphNode, config: Config) -> NodeResult | None:
+        """Re-dispatch on restart — wait conditions must be re-evaluated."""
+        return None

--- a/src/breadforge/graph/node.py
+++ b/src/breadforge/graph/node.py
@@ -3,11 +3,10 @@
 Re-exports GraphNode/PlanArtifact/NodeType/NodeState from beads.types for
 convenience, and adds NodeResult + NodeHandler protocol used by handlers.
 
-Extended node types (wait/consensus/design_doc) are defined here as
-ExtendedNodeType.  Nodes with these types must be constructed via
-make_node() which uses model_construct() to bypass Pydantic's Literal
-validation on GraphNode.type.  Full persistence of extended types requires
-updating NodeType in beads/types.py.
+NodeType (defined in beads/types.py) includes all supported types including
+the extended types: wait, consensus, design_doc.  ExtendedNodeType is kept
+as an alias for backward compatibility.  Use make_node() for programmatic
+node construction; GraphNode() can be used directly for all node types.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Create `src/breadforge/graph/handlers/wait.py` with a condition-based `WaitHandler` supporting `always_true`, `always_false`, and `file_exists` conditions with configurable `poll_interval` and `max_polls`
- Extend `NodeType` in `beads/types.py` to include `wait`, `consensus`, `design_doc` so extended node types can be properly persisted and deserialized via `BeadStore.read_node()`
- Update `node.py` docstring to reflect that `NodeType` now covers all node types

## Test plan

- [x] `tests/test_wait_handler.py` — all 10 tests pass (condition evaluation, poll counting, executor integration)
- [x] `tests/test_consensus.py` — all tests pass
- [x] `tests/unit/test_graph_node.py` — all tests pass including `BeadStore` read/write roundtrip
- [x] `ruff check` — clean on all modified files
- [x] Pre-existing failures in `test_assessor.py` (3 tests) caused by `BREADFORGE_MODEL` env var — not related to this change

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)