### PR TITLE
feat(graph): wire validate/bug nodes in builder and executor

### DIFF
--- a/src/breadforge/graph/builder.py
+++ b/src/breadforge/graph/builder.py
@@ -375,3 +375,106 @@ def emit_design_doc_node(
         context=context,
         max_retries=2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Validate and bug node emitters
+# ---------------------------------------------------------------------------
+
+
+def emit_validate_node(
+    milestone: str,
+    repo: str,
+    assertions: list[str],
+    depends_on: list[str] | None = None,
+    fix_cycle: int = 0,
+    milestone_issue_number: int | None = None,
+) -> GraphNode:
+    """Create a validate node that runs assertion commands after readme completes.
+
+    The validate node runs each assertion command as a subprocess; a non-zero
+    exit code signals failure.  On failure the validate handler emits one bug
+    node per failed assertion.  On clean pass it closes the milestone tracking
+    issue.
+
+    Args:
+        milestone: The milestone slug (e.g. ``"v1"``).
+        repo: ``owner/repo`` string.
+        assertions: List of shell commands to execute as assertions.
+        depends_on: Node IDs this node depends on (typically the readme node ID).
+        fix_cycle: How many fix cycles have already been attempted.  Starts at 0.
+        milestone_issue_number: GitHub issue number of the milestone tracker issue.
+
+    Returns:
+        A :class:`GraphNode` with type ``"validate"``.
+    """
+    context: dict = {
+        "milestone": milestone,
+        "repo": repo,
+        "assertions": assertions,
+        "fix_cycle": fix_cycle,
+    }
+    if milestone_issue_number is not None:
+        context["milestone_issue_number"] = milestone_issue_number
+    return make_node(
+        id=f"{milestone}-validate",
+        type="validate",
+        depends_on=depends_on or [],
+        context=context,
+        max_retries=3,
+    )
+
+
+def emit_bug_node(
+    milestone: str,
+    repo: str,
+    assertion: str,
+    exit_code: int,
+    stdout: str,
+    stderr: str,
+    fix_cycle: int = 1,
+    milestone_issue_number: int | None = None,
+    depends_on: list[str] | None = None,
+) -> GraphNode:
+    """Create a bug node that files a GitHub issue and emits a build fix node.
+
+    Bug nodes are emitted by the validate handler when an assertion fails.
+    Each bug node files a GitHub issue with the failure details and emits a
+    build node scoped to fix the issue.
+
+    Args:
+        milestone: The milestone slug.
+        repo: ``owner/repo`` string.
+        assertion: The exact shell command that failed.
+        exit_code: The process exit code from the failing assertion.
+        stdout: Captured stdout from the failing command.
+        stderr: Captured stderr from the failing command.
+        fix_cycle: Which fix cycle this bug is being filed in (1-indexed).
+        milestone_issue_number: GitHub issue number of the milestone tracker issue.
+        depends_on: Node IDs this node depends on.
+
+    Returns:
+        A :class:`GraphNode` with type ``"bug"``.
+    """
+    import hashlib
+
+    # Derive a short stable slug from the assertion text for the node ID
+    digest = hashlib.sha1(assertion.encode()).hexdigest()[:8]
+    context: dict = {
+        "milestone": milestone,
+        "repo": repo,
+        "assertion": assertion,
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "fix_cycle": fix_cycle,
+    }
+    if milestone_issue_number is not None:
+        context["milestone_issue_number"] = milestone_issue_number
+    return make_node(
+        id=f"{milestone}-bug-{digest}",
+        type="bug",
+        depends_on=depends_on or [],
+        context=context,
+        max_retries=1,
+    )

--- a/src/breadforge/graph/executor.py
+++ b/src/breadforge/graph/executor.py
@@ -470,7 +470,7 @@ def make_handlers(
     from breadforge.graph.handlers.readme import ReadmeHandler
     from breadforge.graph.handlers.research import ResearchHandler
 
-    return {
+    handlers: dict[NodeType, NodeHandler] = {
         "plan": PlanHandler(store=store, logger=logger),
         "research": ResearchHandler(store=store, logger=logger),
         "build": BuildHandler(store=store, logger=logger),
@@ -481,3 +481,23 @@ def make_handlers(
         "consensus": ConsensusHandler(store=store, logger=logger),
         "design_doc": DesignDocHandler(store=store, logger=logger),
     }
+
+    # validate and bug handlers — imported defensively; these handler files may
+    # be built in a parallel milestone PR.  If they exist, register them; if not,
+    # the executor will return a "no handler" error for those node types at
+    # runtime (better than crashing at import time).
+    try:
+        from breadforge.graph.handlers.validate import ValidateHandler
+
+        handlers["validate"] = ValidateHandler(store=store, logger=logger)  # type: ignore[index]
+    except ImportError:
+        pass
+
+    try:
+        from breadforge.graph.handlers.bug import BugHandler
+
+        handlers["bug"] = BugHandler(store=store, logger=logger)  # type: ignore[index]
+    except ImportError:
+        pass
+
+    return handlers

--- a/tests/unit/test_graph_builder_validate.py
+++ b/tests/unit/test_graph_builder_validate.py
@@ -1,0 +1,251 @@
+"""Unit tests for validate and bug node emitters in graph/builder.py, and
+for the validate/bug handler registration in executor.py make_handlers()."""
+
+from __future__ import annotations
+
+from breadforge.graph.builder import emit_bug_node, emit_validate_node
+from breadforge.graph.executor import make_handlers
+
+# ---------------------------------------------------------------------------
+# emit_validate_node
+# ---------------------------------------------------------------------------
+
+
+class TestEmitValidateNode:
+    def test_basic_structure(self) -> None:
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=["bw status --json | jq -e '.ok'"],
+        )
+        assert node.id == "v1-validate"
+        assert node.type == "validate"
+        assert node.context["milestone"] == "v1"
+        assert node.context["repo"] == "owner/repo"
+        assert node.context["assertions"] == ["bw status --json | jq -e '.ok'"]
+        assert node.context["fix_cycle"] == 0
+        assert node.depends_on == []
+        assert node.max_retries == 3
+
+    def test_depends_on_readme(self) -> None:
+        node = emit_validate_node(
+            milestone="v2",
+            repo="owner/repo",
+            assertions=["echo ok"],
+            depends_on=["v2-readme"],
+        )
+        assert "v2-readme" in node.depends_on
+
+    def test_fix_cycle_stored(self) -> None:
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=["echo ok"],
+            fix_cycle=2,
+        )
+        assert node.context["fix_cycle"] == 2
+
+    def test_milestone_issue_number_included_when_given(self) -> None:
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=["echo ok"],
+            milestone_issue_number=42,
+        )
+        assert node.context["milestone_issue_number"] == 42
+
+    def test_milestone_issue_number_absent_when_not_given(self) -> None:
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=["echo ok"],
+        )
+        assert "milestone_issue_number" not in node.context
+
+    def test_multiple_assertions(self) -> None:
+        assertions = [
+            "bw speculate --dry-run --json | jq -e '.ok'",
+            "bw heartbeat --json | jq -e '.checked >= 0'",
+        ]
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=assertions,
+        )
+        assert node.context["assertions"] == assertions
+
+    def test_empty_assertions(self) -> None:
+        node = emit_validate_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertions=[],
+        )
+        assert node.context["assertions"] == []
+
+
+# ---------------------------------------------------------------------------
+# emit_bug_node
+# ---------------------------------------------------------------------------
+
+
+class TestEmitBugNode:
+    def test_basic_structure(self) -> None:
+        node = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="bw speculate --dry-run",
+            exit_code=1,
+            stdout="",
+            stderr="Error: not found",
+        )
+        assert node.type == "bug"
+        assert node.id.startswith("v1-bug-")
+        assert node.context["milestone"] == "v1"
+        assert node.context["repo"] == "owner/repo"
+        assert node.context["assertion"] == "bw speculate --dry-run"
+        assert node.context["exit_code"] == 1
+        assert node.context["stdout"] == ""
+        assert node.context["stderr"] == "Error: not found"
+        assert node.context["fix_cycle"] == 1
+        assert node.depends_on == []
+        assert node.max_retries == 1
+
+    def test_node_id_is_deterministic(self) -> None:
+        """Same assertion always yields the same node ID."""
+        assertion = "bw speculate --dry-run --json | jq -e '.ok'"
+        node1 = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion=assertion,
+            exit_code=1,
+            stdout="",
+            stderr="",
+        )
+        node2 = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion=assertion,
+            exit_code=1,
+            stdout="",
+            stderr="",
+        )
+        assert node1.id == node2.id
+
+    def test_different_assertions_different_ids(self) -> None:
+        node_a = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="cmd a",
+            exit_code=1,
+            stdout="",
+            stderr="",
+        )
+        node_b = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="cmd b",
+            exit_code=1,
+            stdout="",
+            stderr="",
+        )
+        assert node_a.id != node_b.id
+
+    def test_fix_cycle_stored(self) -> None:
+        node = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="echo ok",
+            exit_code=2,
+            stdout="out",
+            stderr="err",
+            fix_cycle=3,
+        )
+        assert node.context["fix_cycle"] == 3
+
+    def test_milestone_issue_number_included_when_given(self) -> None:
+        node = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="echo ok",
+            exit_code=1,
+            stdout="",
+            stderr="",
+            milestone_issue_number=99,
+        )
+        assert node.context["milestone_issue_number"] == 99
+
+    def test_milestone_issue_number_absent_when_not_given(self) -> None:
+        node = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="echo ok",
+            exit_code=1,
+            stdout="",
+            stderr="",
+        )
+        assert "milestone_issue_number" not in node.context
+
+    def test_depends_on(self) -> None:
+        node = emit_bug_node(
+            milestone="v1",
+            repo="owner/repo",
+            assertion="echo ok",
+            exit_code=1,
+            stdout="",
+            stderr="",
+            depends_on=["v1-validate"],
+        )
+        assert "v1-validate" in node.depends_on
+
+
+# ---------------------------------------------------------------------------
+# make_handlers — validate and bug registration
+# ---------------------------------------------------------------------------
+
+
+class TestMakeHandlers:
+    def test_core_handlers_present(self) -> None:
+        handlers = make_handlers()
+        for key in (
+            "plan",
+            "research",
+            "build",
+            "merge",
+            "readme",
+            "wait",
+            "consensus",
+            "design_doc",
+        ):
+            assert key in handlers, f"handler {key!r} missing from make_handlers()"
+
+    def test_validate_handler_registered_when_module_available(self) -> None:
+        """If validate.py exists, 'validate' key is in handlers."""
+        import importlib
+
+        try:
+            importlib.import_module("breadforge.graph.handlers.validate")
+        except ImportError:
+            # Handler not yet built — skip this assertion
+            return
+
+        handlers = make_handlers()
+        assert "validate" in handlers
+
+    def test_bug_handler_registered_when_module_available(self) -> None:
+        """If bug.py exists, 'bug' key is in handlers."""
+        import importlib
+
+        try:
+            importlib.import_module("breadforge.graph.handlers.bug")
+        except ImportError:
+            return
+
+        handlers = make_handlers()
+        assert "bug" in handlers
+
+    def test_make_handlers_does_not_raise_when_handlers_missing(self) -> None:
+        """make_handlers() must not raise even if validate.py / bug.py are absent."""
+        # This test verifies the defensive import pattern works without side effects.
+        handlers = make_handlers()
+        assert isinstance(handlers, dict)
+        assert len(handlers) >= 8


### PR DESCRIPTION
## Summary

- Adds `emit_validate_node` and `emit_bug_node` helpers to `graph/builder.py`
- `emit_validate_node` produces a validate node with `milestone`, `repo`, `assertions`, `fix_cycle`, and optional `milestone_issue_number` in context; caller wires the `depends_on` (typically the readme node ID)
- `emit_bug_node` produces a bug node with full failure details (`assertion`, `exit_code`, `stdout`, `stderr`, `fix_cycle`); node ID is `{milestone}-bug-{sha1[:8]}` of the assertion for stability
- Registers `validate` and `bug` handler types in `make_handlers()` in `executor.py` using defensive imports — if the handler files are not yet present (built in a parallel PR), `make_handlers()` skips them silently rather than raising at import time
- Backward compatible: specs without a `## Validation` section emit no validate node; `make_handlers()` always returns at least the 8 core handlers

## Test plan

- [x] `uv run pytest` — 449 tests pass, no new failures
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

Closes #53